### PR TITLE
Implement NextJS caching for external API request.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_GUPY_ENDPOINT=https://portal.api.gupy.io/api/v1/jobs
+NEXT_PUBLIC_CORS_BP=https://cors-everywhere.onrender.com/
+NEXT_PUBLIC_ENV=local

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_GUPY_ENDPOINT=https://portal.api.gupy.io/api/v1/jobs
+NEXT_PUBLIC_CORS_BP=https://cors-everywhere.onrender.com/
+NEXT_PUBLIC_ENV=production

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+Install all dependencies:
+```bash
+npm install ( require node > 18)
+```
+
+Make a copy of env file, renaming it to .env.local
+
+Then, run the development server:
 
 ```bash
 npm run dev

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,13 +1,35 @@
 async function getVacancys(role: string) {
+  const query = {
+    limit: '20',
+    jobName: role,
+    isRemoteWork: 'true',
+    type: 'vacancy_type_effective',
+  };
+
+  if (
+    !process.env.NEXT_PUBLIC_GUPY_ENDPOINT
+    || !process.env.NEXT_PUBLIC_CORS_BP
+  ) {
+    throw new Error('Environment variables are not set');
+  }
+
+  const endpoint = process.env.NEXT_PUBLIC_GUPY_ENDPOINT;
+  const cors = process.env.NEXT_PUBLIC_CORS_BP;
+
+  const finalEndpoint = `${cors}${endpoint}?${new URLSearchParams(query)}`;
+
   const response = await fetch(
-    `https://cors-everywhere.onrender.com/https://portal.api.gupy.io/api/v1/jobs?&limit=3000&jobName=${role}&isRemoteWork=true&type=vacancy_type_effective`,
+    finalEndpoint,
     {
-      cache: "no-store",
+      cache: "force-cache",
       headers: {
         Origin: "http://localhost:3000",
         Referer: "http://localhost:3000",
       },
-    }
+      next: {
+        revalidate: 3600
+      },
+    },
   );
   const data = await response.json();
 


### PR DESCRIPTION
Olá, gostaria de dar meu centavo de contribuição.

Gostei muito da aplicação, meus parabéns primeiramente. Segundamente, proponha essa pequena melhoria. É uma mudanças sútil mas que vai surtir um efeito muito grande na aplicação.

O ponto forte do next acho que é toda essa estrutura de geração estática e caching. Inclusive pra requisições web ele também oferece um cache. Partindo do pressuposto que não temos vagas sendo abertas a cada minuto achei que seria muito melhor usar uma estratégio de cache simples pra garantir mais estabilidade a aplicação. Por isso fiz essa pequena alteração que cacheia os resultados da busca na API, e revalida esses dados a cada hora. Nos meus testes locais sem o cache o tempo era de 500ms em média, e com o cache caiu pra ~3ms, após cacheado.

Estas é minha primeiras contribuição para o projeto :) Estou aberto a críticas e sugestões também.

Env: https://be-dev-app-git-feature-cache-results-juunr95.vercel.app/